### PR TITLE
Add "no mappings" global option

### DIFF
--- a/doc/HowMuch.txt
+++ b/doc/HowMuch.txt
@@ -174,6 +174,7 @@ OPTIONS																												*HowMuch-options*
 	|g:loaded_HowMuch| .................. disable HowMuch plugin
 	|g:HowMuch_scale| ................... set scale of float result
 	|g:HowMuch_auto_engines| ............ engine list for |auto-calc|
+	|g:HowMuch_no_mappings| ............. disable default mappings
 	|g:HowMuch_debug| ................... if turn on debug mode
 	|g:HowMuch_engine_map| .............. (advanced option) availabe engines map 
 
@@ -200,6 +201,11 @@ option is |List| default value is: >
 Use this option to show more debug message. Debug information by default is
 disabled. >
 	let g:HowMuch_debug = 0
+<
+ 																															*g:HowMuch_no_mappings*
+Set this option to 1 to disable the default mappings. Mappings are defined
+by default for every possible calculator and configuration. >
+	let g:HowMuch_no_mappings = 0
 <
   																												*g:HowMuch_engine_map*
 The value of this option is a vim |Dictionary|. The key is an engine name. The

--- a/plugin/HowMuch.vim
+++ b/plugin/HowMuch.vim
@@ -74,6 +74,10 @@ vnoremap <silent><unique> <Plug>PyCalcAppendWithEqAndSum   :call HowMuch#HowMuch
 "}}}
 
 "===========================================================
+"optionally skip default mappings
+if exists('g:HowMuch_no_mappings') && g:HowMuch_no_mappings
+  finish
+endif
 
 "default mappings for auto
 "{{{


### PR DESCRIPTION
Many popular vim plugins include an option to disable the default mappings. This is convenient for power users with hundreds of existing mappings that only want to use a subset of the plugin functionality (and therefore only need a couple custom mappings in their `.vimrc`, or maybe only ever want to use the manual `:HowMuch` command provided by this plugin).

This PR adds a `g:HowMuch_no_mappings` option. If set to `1`, the lines following the `<Plug>HowMuch` definitions in `plugin/HowMuch.vim` are skipped. Users like me can then define their own mappings in their `.vimrc`.